### PR TITLE
Add active_fedora-noid gem. Set up verbatim from readme.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,6 @@
 /log/*
 !/log/.keep
 /tmp
-
+noid-minter-state
 
 /jetty

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem "rsolr", "~> 1.0.6"
 gem "devise"
 gem "devise-guests", "~> 0.3"
 
+# from https://github.com/projecthydra-labs/active_fedora-noid
+gem 'active_fedora-noid'
+
 group :development, :test do
   gem "rspec-rails"
   gem "jettywrapper"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,9 @@ GEM
     active_attr (0.8.5)
       activemodel (>= 3.0.2, < 5.0)
       activesupport (>= 3.0.2, < 5.0)
+    active_fedora-noid (0.1.0)
+      active-fedora
+      noid
     activemodel (4.1.8)
       activesupport (= 4.1.8)
       builder (~> 3.1)
@@ -535,6 +538,7 @@ PLATFORMS
 
 DEPENDENCIES
   active-fedora!
+  active_fedora-noid
   byebug
   capybara
   coffee-rails (~> 4.0.0)

--- a/app/models/concerns/noid_behaviors.rb
+++ b/app/models/concerns/noid_behaviors.rb
@@ -1,0 +1,16 @@
+require 'active_fedora/noid'
+
+module NoidBehaviors
+  extend ActiveSupport::Concern
+
+  def assign_id
+    noid_service.mint
+  end
+
+  private
+
+  def noid_service
+    @noid_service ||= ActiveFedora::Noid::Service.new
+  end
+
+end

--- a/app/models/scanned_book.rb
+++ b/app/models/scanned_book.rb
@@ -1,9 +1,13 @@
 # Generated via
 #  `rails generate worthwhile:work ScannedBook`
+
+require 'active_fedora/noid'
+
 class ScannedBook < ActiveFedora::Base
   include ::CurationConcern::Work
   include Sufia::GenericFile::Metadata
   include PulMetadataServices::ExternalMetadataSource
+  include ::NoidBehaviors
 
   property :portion_note, predicate: ::RDF::URI.new(::RDF::DC.description), multiple: false
   property :description, predicate: ::RDF::URI.new(::RDF::DC.abstract), multiple: false
@@ -82,6 +86,16 @@ class ScannedBook < ActiveFedora::Base
   # http://stackoverflow.com/questions/1235863/test-if-a-string-is-basically-an-integer-in-quotes-using-ruby
   def is_bibdata?
     /\A[-+]?\d+\z/ === self.source_metadata_id
+  end
+
+  def assign_id
+    noid_service.mint
+  end
+
+  private
+
+  def noid_service
+    @noid_service ||= ActiveFedora::Noid::Service.new
   end
 
 end

--- a/config/initializers/active_fedora.rb
+++ b/config/initializers/active_fedora.rb
@@ -1,0 +1,3 @@
+# for noid minter
+ActiveFedora::Base.translate_uri_to_id = ActiveFedora::Noid.config.translate_uri_to_id
+ActiveFedora::Base.translate_id_to_uri = ActiveFedora::Noid.config.translate_id_to_uri

--- a/config/initializers/active_fedora_noid.rb
+++ b/config/initializers/active_fedora_noid.rb
@@ -1,0 +1,7 @@
+require 'active_fedora/noid'
+
+ActiveFedora::Noid.configure do |config|
+  config.statefile = 'noid-minter-state'
+  config.template = 'd.zdeeek'
+  #config.seed = '153572761077996293261137207563891833346'
+end

--- a/spec/models/scanned_book_spec.rb
+++ b/spec/models/scanned_book_spec.rb
@@ -129,7 +129,13 @@ describe ScannedBook do
     end
   end
 
-  # it "Validates the ID as either a Pulfa or Voyager ID" do
+  describe "gets a noid" do
 
-  # end
+    it "that conforms to a valid pattern" do
+      expect { subject.save }.to_not raise_error
+      noid_service = ActiveFedora::Noid::Service.new
+      expect(noid_service.valid? subject.id).to be_truthy 
+    end
+  end
+
 end


### PR DESCRIPTION
Have .gitignore ignore the noid minter file. Use the noid template pattern from pul-store. Add initializers for active fedora and the active fedora noid gem per the active fedora noid readme. Includes basic test to make sure noids minting on objects are valid according to the supplied noid pattern. Closes #23.
